### PR TITLE
Fix scope of timeunit declaration

### DIFF
--- a/tb/tb_hwpe_ctrl_seq_mult.sv
+++ b/tb/tb_hwpe_ctrl_seq_mult.sv
@@ -13,10 +13,11 @@
  * specific language governing permissions and limitations under the License.
  */
 
-timeunit 1ns;
-timeprecision 1ps;
 
 module tb_hwpe_ctrl_seq_mult;
+
+  timeunit 1ns;
+  timeprecision 1ps;
 
   localparam AW = 8;
   localparam BW = 8;


### PR DESCRIPTION
By putting the timeunit declaration outside of the module declaration it
affects the whole compilation unit. This breaks PULPissimo when trying
to use a different simulator.