### PR TITLE
Update dependencies and build order in Bender.yml, use non-deprecated clk_gating

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -4,18 +4,25 @@ package:
     - "Francesco Conti <f.conti@unibo.it>"
 
 dependencies:
-  tech_cells_generic: { git: "git@github.com:pulp-platform/tech_cells_generic.git", version: 0.1.6 }
+  tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.2 }
 
 sources:
   - include_dirs:
       - rtl
     files:
-      - rtl/hwpe_ctrl_package.sv
+      # Source files grouped in levels. Files in level 0 have no dependencies on files in this
+      # package. Files in level 1 only depend on files in level 0, files in level 2 on files in
+      # levels 1 and 0, etc. Files within a level are ordered alphabetically.
+      # Level 0
       - rtl/hwpe_ctrl_interfaces.sv
-      - rtl/hwpe_ctrl_regfile.sv
+      - rtl/hwpe_ctrl_package.sv
+      # Level 1
       - rtl/hwpe_ctrl_regfile_latch.sv
-      - rtl/hwpe_ctrl_regfile_latch_test_wrap.sv
-      - rtl/hwpe_ctrl_slave.sv
       - rtl/hwpe_ctrl_seq_mult.sv
       - rtl/hwpe_ctrl_uloop.sv
-
+      # Level 2
+      - rtl/hwpe_ctrl_regfile_latch_test_wrap.sv
+      # Level 3
+      - rtl/hwpe_ctrl_regfile.sv
+      # Level 4
+      - rtl/hwpe_ctrl_slave.sv

--- a/rtl/hwpe_ctrl_regfile_latch.sv
+++ b/rtl/hwpe_ctrl_regfile_latch.sv
@@ -62,8 +62,7 @@ module hwpe_ctrl_regfile_latch
    genvar                                       x;
    genvar                                       y;
    
-   cluster_clock_gating CG_WE_GLOBAL
-   (
+   tc_clk_gating CG_WE_GLOBAL (
       .clk_o     ( clk_int             ),
       .en_i      ( WriteEnable | clear ),
       .test_en_i ( 1'b0                ),
@@ -119,8 +118,7 @@ module hwpe_ctrl_regfile_latch
         begin : CG_CELL_WORD_ITER
            for(y=0; y<NUM_BYTE; y++)
              begin : CG_CELL_BYTE_ITER
-                 cluster_clock_gating CG_Inst
-                  (
+                 tc_clk_gating CG_Inst (
                    .clk_o(ClocksxC[x][y]),
                    .en_i(WAddrOneHotxD[x][y]),
                    .test_en_i(1'b0),


### PR DESCRIPTION
Hi @FrancescoConti,
I hope these changes are ok, please let me know if you have questions.
If possible, it would be great to have a release of this repository once merged, I believe `v1.6.2` could make sense.