### PR TITLE
Move package imports to module scope

### DIFF
--- a/rtl/hwpe_ctrl_regfile.sv
+++ b/rtl/hwpe_ctrl_regfile.sv
@@ -13,9 +13,9 @@
  * specific language governing permissions and limitations under the License.
  */
 
-import hwpe_ctrl_package::*;
 
 module hwpe_ctrl_regfile
+  import hwpe_ctrl_package::*;
 #(
   parameter int unsigned N_CONTEXT      = REGFILE_N_CONTEXT,
   parameter int unsigned ID_WIDTH       = 16,

--- a/rtl/hwpe_ctrl_seq_mult.sv
+++ b/rtl/hwpe_ctrl_seq_mult.sv
@@ -16,9 +16,9 @@
  * be kept stable for AW-1 cycles after the start strobe.
  */
 
-import hwpe_ctrl_package::*;
 
-module hwpe_ctrl_seq_mult 
+module hwpe_ctrl_seq_mult
+  import hwpe_ctrl_package::*;
 #(
   parameter int unsigned AW = 8,
   parameter int unsigned BW = 8

--- a/rtl/hwpe_ctrl_slave.sv
+++ b/rtl/hwpe_ctrl_slave.sv
@@ -13,9 +13,9 @@
  * specific language governing permissions and limitations under the License.
  */
 
-import hwpe_ctrl_package::*;
 
 module hwpe_ctrl_slave
+  import hwpe_ctrl_package::*;
 #(
   parameter int unsigned N_CORES        = 4,
   parameter int unsigned N_CONTEXT      = 2,

--- a/rtl/hwpe_ctrl_uloop.sv
+++ b/rtl/hwpe_ctrl_uloop.sv
@@ -18,9 +18,9 @@
  * ones.
  */
 
-import hwpe_ctrl_package::*;
 
 module hwpe_ctrl_uloop
+  import hwpe_ctrl_package::*;
 #(
   parameter int unsigned LENGTH        = hwpe_ctrl_package::ULOOP_MAX_LENGTH,
   parameter int unsigned NB_LOOPS      = hwpe_ctrl_package::ULOOP_MAX_NB_LOOPS,

--- a/tb/tb_hwpe_ctrl_uloop.sv
+++ b/tb/tb_hwpe_ctrl_uloop.sv
@@ -17,9 +17,9 @@
 timeunit 1ps;
 timeprecision 1ps;
 
-import hwpe_ctrl_package::*;
 
 module tb_hwpe_ctrl_uloop;
+  import hwpe_ctrl_package::*;
 
   // parameters
   parameter int unsigned NB_LOOPS  = hwpe_ctrl_package::ULOOP_NB_LOOPS;


### PR DESCRIPTION
Import packages into the compilation unit scope (meaning you put the import before the module declaration) is very bad practice. Depending on the tool (whether it puts every file into one single compilation unit or every file in its own compilation unit), it causes imported symbols with identical name to be overriden. Instead, the import should happen after the module name declaration before the parameter list. That way, the import is scoped to the module.