### PR TITLE
Introduce separate COMMIT & TRIGGER mechanism

### DIFF
--- a/rtl/hwpe_ctrl_package.sv
+++ b/rtl/hwpe_ctrl_package.sv
@@ -73,6 +73,7 @@ package hwpe_ctrl_package;
     logic                                 is_critical;
     logic                                 is_testset;
     logic                                 is_trigger;
+    logic                                 is_commit;
     logic                                 is_working;
     logic [$clog2(REGFILE_N_CONTEXT)-1:0] pointer_context;
     logic [$clog2(REGFILE_N_CONTEXT)-1:0] running_context;


### PR DESCRIPTION
The old TRIGGER register functionality is split in two:
 - COMMIT: every time a write is performed to this register, the
   job queue is advanced. COMMIT does not include, however, the
   automatic triggering of a job
 - TRIGGER: only if the write has value 0x0, it includes also the
   automatic triggering of jobs. Automatic triggering is disabled
   only when the queue is emptied.