### PR TITLE
Fix uloop flags `ready` value

### DIFF
--- a/rtl/hwpe_ctrl_uloop.sv
+++ b/rtl/hwpe_ctrl_uloop.sv
@@ -332,7 +332,7 @@ module hwpe_ctrl_uloop
       begin
         flags_o = shadow_flags_rd;
         flags_o.valid = out_valid;
-        flags_o.ready = shadow_flags_wr.valid;
+        flags_o.ready = shadow_flags_wr.ready;
         flags_o.loop  = out_loop;
       end
 


### PR DESCRIPTION
With this commit, uloop flag `ready` is tied to the ready of the shadowed write `flags` register of the