### PR TITLE
Exposed signals to observe the next tiles. It is helpful to enable prefetchin in N-EUREKA

### DIFF
--- a/rtl/hwpe_ctrl_package.sv
+++ b/rtl/hwpe_ctrl_package.sv
@@ -1,7 +1,7 @@
 /*
  * hwpe_ctrl_package.sv
  * Francesco Conti <f.conti@unibo.it>
- *
+ * Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  * Copyright (C) 2014-2018 ETH Zurich, University of Bologna
  * Copyright and related rights are licensed under the Solderpad Hardware
  * License, Version 0.51 (the "License"); you may not use this file except in
@@ -114,11 +114,15 @@ package hwpe_ctrl_package;
     logic                                                   valid;
     logic                                                   ready;
     logic [ULOOP_MAX_NB_REG-1:0]  [31:0]                    offs;
+    logic [ULOOP_MAX_NB_REG-1:0]  [31:0]                    next_offs;
     logic [ULOOP_MAX_NB_LOOPS-1:0][ULOOP_MAX_CNT_WIDTH-1:0] idx;
+    logic [ULOOP_MAX_NB_LOOPS-1:0][ULOOP_MAX_CNT_WIDTH-1:0] next_idx;
     logic [ULOOP_MAX_NB_LOOPS-1:0]                          idx_update;
+    logic                                                   next_valid;
+    logic                                                   next_done;
     logic [$clog2(ULOOP_MAX_NB_LOOPS)-1:0]                  loop;
   } flags_uloop_t;
-
+  
   typedef struct packed {
     logic [4:0] uloop_addr;
     logic [3:0] nb_ops;

--- a/rtl/hwpe_ctrl_uloop.sv
+++ b/rtl/hwpe_ctrl_uloop.sv
@@ -1,6 +1,7 @@
 /*
  * hwpe_ctrl_uloop.sv
  * Francesco Conti <fconti@iis.ee.ethz.ch>
+ * Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  *
  * Copyright (C) 2014-2018 ETH Zurich, University of Bologna
  * Copyright and related rights are licensed under the Solderpad Hardware
@@ -330,7 +331,15 @@ module hwpe_ctrl_uloop
 
       always_comb
       begin
+        flags_o.next_idx  = 0;
         flags_o = shadow_flags_rd;
+        flags_o.next_offs = registers;
+        flags_o.next_valid = flags_valid;
+        flags_o.next_done  = done_int;
+        for(int i=0; i<NB_LOOPS; i++) begin 
+          flags_o.next_idx[i]  = curr_idx[i];
+        end 
+        // flags_o.next_idx  = curr_idx;
         flags_o.valid = out_valid;
         flags_o.ready = shadow_flags_wr.valid;
         flags_o.loop  = out_loop;


### PR DESCRIPTION
This commit by @arpansur exposes the next tile indeces from the uloop, to enable prefetching activities.