### PR TITLE
Add support for number of contexts>2

### DIFF
--- a/rtl/hwpe_ctrl_package.sv
+++ b/rtl/hwpe_ctrl_package.sv
@@ -16,7 +16,8 @@
 package hwpe_ctrl_package;
 
   parameter int unsigned REGFILE_N_MAX_CORES        = 16;
-  parameter int unsigned REGFILE_N_CONTEXT          = 2;
+  parameter int unsigned REGFILE_N_MAX_CONTEXT      = 8;
+  parameter int unsigned REGFILE_N_DEFAULT_CONTEXT  = 2;
   parameter int unsigned REGFILE_N_EVT              = 2;
   parameter int unsigned REGFILE_N_REGISTERS        = 64;
   parameter int unsigned REGFILE_N_MANDATORY_REGS   = 8;
@@ -65,18 +66,18 @@ package hwpe_ctrl_package;
   } regfile_out_t;
 
   typedef struct packed {
-    logic                                 true_done;
-    logic                                 full_context;
-    logic                                 is_mandatory;
-    logic                                 is_read;
-    logic                                 is_contexted;
-    logic                                 is_critical;
-    logic                                 is_testset;
-    logic                                 is_trigger;
-    logic                                 is_commit;
-    logic                                 is_working;
-    logic [$clog2(REGFILE_N_CONTEXT)-1:0] pointer_context;
-    logic [$clog2(REGFILE_N_CONTEXT)-1:0] running_context;
+    logic                                     true_done;
+    logic                                     full_context;
+    logic                                     is_mandatory;
+    logic                                     is_read;
+    logic                                     is_contexted;
+    logic                                     is_critical;
+    logic                                     is_testset;
+    logic                                     is_trigger;
+    logic                                     is_commit;
+    logic                                     is_working;
+    logic [$clog2(REGFILE_N_MAX_CONTEXT)-1:0] pointer_context;
+    logic [$clog2(REGFILE_N_MAX_CONTEXT)-1:0] running_context;
      // Extension
     logic         ext_we;
     logic         ext_re;       // Register on bus is extension port

--- a/rtl/hwpe_ctrl_regfile.sv
+++ b/rtl/hwpe_ctrl_regfile.sv
@@ -18,7 +18,7 @@ module hwpe_ctrl_regfile
   import hwpe_ctrl_package::*;
 #(
   parameter int unsigned REGFILE_SCM    = 1,
-  parameter int unsigned N_CONTEXT      = REGFILE_N_CONTEXT,
+  parameter int unsigned N_CONTEXT      = REGFILE_N_DEFAULT_CONTEXT,
   parameter int unsigned ID_WIDTH       = 16,
   parameter int unsigned N_IO_REGS      = 2,
   parameter int unsigned N_GENERIC_REGS = 0,


### PR DESCRIPTION
This PR introduces the constant **REGFILE_N_MAX_CONTEXT** and sets its value to 8. This change enables **N_CONTEXT** to be passed freely (up to 8) to `hwpe_ctrl_regfile`, which now defaults to N_CONTEXT=**REGFILE_N_DEFAULT_CONTEXT**.

Previously, the definition of `flags_regfile_t` in the package caused issues because the `pointer_context` and `running_context` fields were assigned bit widths of `$clog2(REGFILE_N_CONTEXT=2)`.