### PR TITLE
Fixup for VCS compatibility

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -1,6 +1,6 @@
 package:
   name: hwpe-ctrl
-  authors: 
+  authors:
     - "Francesco Conti <f.conti@unibo.it>"
 
 dependencies:
@@ -14,8 +14,8 @@ sources:
       # package. Files in level 1 only depend on files in level 0, files in level 2 on files in
       # levels 1 and 0, etc. Files within a level are ordered alphabetically.
       # Level 0
-      - rtl/hwpe_ctrl_interfaces.sv
       - rtl/hwpe_ctrl_package.sv
+      - rtl/hwpe_ctrl_interfaces.sv
       # Level 1
       - rtl/hwpe_ctrl_regfile_ff.sv
       - rtl/hwpe_ctrl_regfile_latch.sv

--- a/rtl/hwpe_ctrl_interfaces.sv
+++ b/rtl/hwpe_ctrl_interfaces.sv
@@ -13,11 +13,13 @@
  * specific language governing permissions and limitations under the License.
  */
 
-interface hwpe_ctrl_intf_periph (
+interface hwpe_ctrl_intf_periph
+  import hwpe_ctrl_package::*;
+(
   input logic clk
 );
 
-  parameter int unsigned ID_WIDTH = -1;
+  parameter int unsigned ID_WIDTH = 0;
 
   logic                req;
   logic                gnt;

--- a/rtl/hwpe_ctrl_package.sv
+++ b/rtl/hwpe_ctrl_package.sv
@@ -15,13 +15,18 @@
 
 package hwpe_ctrl_package;
 
-  parameter int unsigned REGFILE_N_MAX_CORES        = 16;
-  parameter int unsigned REGFILE_N_MAX_CONTEXT      = 8;
-  parameter int unsigned REGFILE_N_DEFAULT_CONTEXT  = 2;
-  parameter int unsigned REGFILE_N_EVT              = 2;
-  parameter int unsigned REGFILE_N_REGISTERS        = 64;
-  parameter int unsigned REGFILE_N_MANDATORY_REGS   = 8;
-  parameter int unsigned REGFILE_N_MAX_IO_REGS      = 48;
+  // Return either the argument minus 1 or 0 if 0; useful for IO vector width declaration
+  function automatic integer unsigned iomsb(input integer unsigned width);
+    return (width != 32'd0) ? unsigned'(width - 1) : 32'd0;
+  endfunction
+
+  parameter int unsigned REGFILE_N_MAX_CORES = 16;
+  parameter int unsigned REGFILE_N_MAX_CONTEXT = 8;
+  parameter int unsigned REGFILE_N_DEFAULT_CONTEXT = 2;
+  parameter int unsigned REGFILE_N_EVT = 2;
+  parameter int unsigned REGFILE_N_REGISTERS = 64;
+  parameter int unsigned REGFILE_N_MANDATORY_REGS = 8;
+  parameter int unsigned REGFILE_N_MAX_IO_REGS = 48;
   parameter int unsigned REGFILE_N_MAX_GENERIC_REGS = 8;
   parameter int unsigned REGFILE_N_RESERVED_REGS    = REGFILE_N_REGISTERS-REGFILE_N_MANDATORY_REGS-REGFILE_N_MAX_GENERIC_REGS-REGFILE_N_MAX_IO_REGS;
 


### PR DESCRIPTION
This PR fixes the (somewhat common) slice/range underflows in logic vectors by using the `iomsb` function.
This is a requirement for simulating IPs from this package using VCS.