### PR TITLE
Remove blocking assignment from always_latch block

### DIFF
--- a/rtl/hwpe_ctrl_regfile_latch.sv
+++ b/rtl/hwpe_ctrl_regfile_latch.sv
@@ -166,7 +166,7 @@ module hwpe_ctrl_regfile_latch
              for(l=0; l<NUM_BYTE; l++)
                begin : w_ByteIter
                   if( ClocksxC[k][l] == 1'b1)
-                    MemContentxDP[k][l] = WDataIntxD[l];
+                    MemContentxDP[k][l] <= WDataIntxD[l];
                end
           end
      end


### PR DESCRIPTION
always_latch blocks should only contain blocking assignments. Although seemingly harmless, this blocking assignment causes yosys to AND the signal that should have been connected directly to the input of the memory latch cells with the gated clock.  