### PR TITLE
Re-add autotrigger to hwpe_ctrl_target with delay and masking

### DIFF
--- a/rtl/hwpe_ctrl_regif_example.rdl
+++ b/rtl/hwpe_ctrl_regif_example.rdl
@@ -48,14 +48,20 @@ addrmap hwpe_ctrl_regif_example {
             swacc = true;
         } value[31:0] = 0;
     };
-    // Mandatory RESERVED register. Not to be updated inside HWPEs.
-    reg reserved {
+    // Mandatory AUTOTRIGGER register. Not to be updated inside HWPEs.
+    reg autotrigger {
         field {
             name = "reserved";
             desc = "Reserved.";
             hw = r;
             sw = r;
-        } value[31:0] = 0;
+        } r0[31:1] = 0;
+        field {
+            name = "autotrigger_n";
+            desc = "If 0 (default) trigger automatically the next job when the current is finished. If 1, wait for an explicit trigger.";
+            hw = r;
+            sw = rw;
+        } autotrigger_n[0:0] = 0;
     };
     // Mandatory STATUS register. Not to be updated inside HWPEs.
     reg status {
@@ -97,12 +103,21 @@ addrmap hwpe_ctrl_regif_example {
             swacc = true;
         } value[1:0] = 0;
     };
+    // Mandatory RESERVED register. Not to be updated inside HWPEs.
+    reg reserved {
+        field {
+            name = "reserved";
+            desc = "Reserved.";
+            hw = r;
+            sw = r;
+        } value[31:0] = 0;
+    };
 
     // "mandatory" set of HWPE registers (CONTROL regs). Not to be updated inside HWPEs.
     regfile ctrl_mandatory {
         commit_trigger commit_trigger @ 0x00;
         acquire        acquire        @ 0x04;
-        reserved       reserved0      @ 0x08;
+        autotrigger    autotrigger    @ 0x08;
         status         status         @ 0x0c;
         running_job    running_job    @ 0x10;
         soft_clear     soft_clear     @ 0x14;

--- a/rtl/hwpe_ctrl_target.sv
+++ b/rtl/hwpe_ctrl_target.sv
@@ -204,6 +204,9 @@ module hwpe_ctrl_target
   // current and next running job ID
   logic [7:0] job_running_id_d, job_running_id_q;
 
+  // delayed job done
+  logic job_done_q;
+
   // job commit signal
   logic job_commit;
 
@@ -214,6 +217,20 @@ module hwpe_ctrl_target
   logic                       soft_clear_regfile_d, soft_clear_state_d;
   logic [NB_CLEAR_CYCLES-1:0] soft_clear_regfile_q, soft_clear_state_q;
   logic                       soft_clear_regfile_en, soft_clear_state_en;
+
+  // Registered job_done
+  always_ff @(posedge clk_i or negedge rst_ni)
+  begin
+    if(~rst_ni) begin
+      job_done_q <= '0;
+    end
+    else if(|soft_clear_regfile_q) begin
+      job_done_q <= '0;
+    end
+    else begin
+      job_done_q <= job_done_i;
+    end
+  end
 
   // Registered software-access strobes for the write-command registers.
   // PeakRDL exposes `.value` from the registered field storage (updated one cycle after a
@@ -271,8 +288,9 @@ module hwpe_ctrl_target
 
   // COMMIT_TRIGGER register:
   // Commit a job in the job queue if COMMIT_TRIGGER[1] is 1'b0. Trigger the job queue execution if COMMIT_TRIGGER[0] is 1'b0.
-  assign job_commit    = commit_trigger_swacc_q & ~hwif_out.hwpe_ctrl.commit_trigger.commit_trigger.value[1];
-  assign job_trigger_o = commit_trigger_swacc_q & ~hwif_out.hwpe_ctrl.commit_trigger.commit_trigger.value[0];
+  assign job_commit    =  commit_trigger_swacc_q & ~hwif_out.hwpe_ctrl.commit_trigger.commit_trigger.value[1];
+  assign job_trigger_o = (commit_trigger_swacc_q & ~hwif_out.hwpe_ctrl.commit_trigger.commit_trigger.value[0]) | // trigger when a TRIGGER arrives
+                         (~hwif_out.hwpe_ctrl.autotrigger.autotrigger_n.value & job_done_q & ~job_fifo_empty); // trigger with autotrigger if active and there are pending jobs
 
   // ACQUIRE register:
   // 1. if in ACQUIRE state, respond to any new reads with error code (-2)

--- a/rtl/hwpe_ctrl_target.sv
+++ b/rtl/hwpe_ctrl_target.sv
@@ -310,8 +310,7 @@ module hwpe_ctrl_target
   // COMMIT_TRIGGER register:
   // Commit a job in the job queue if COMMIT_TRIGGER[1] is 1'b0. Trigger the job queue execution if COMMIT_TRIGGER[0] is 1'b0.
 assign job_commit    =  commit_trigger_swacc_q & ~hwif_out.hwpe_ctrl.commit_trigger.commit_trigger.value[1];
-assign job_trigger_o = (commit_trigger_swacc_q & ~hwif_out.hwpe_ctrl.commit_trigger.commit_trigger.value[0] & ~job_running_q &
-                        (job_commit | ~job_fifo_empty)) | // trigger when a TRIGGER arrives, no job is running, and there is (or will be) a job to run
+assign job_trigger_o = (commit_trigger_swacc_q & ~hwif_out.hwpe_ctrl.commit_trigger.commit_trigger.value[0] & ~job_running_q & (job_commit | ~job_fifo_empty)) | // trigger when a TRIGGER arrives, no job is running, and there is (or will be) a job to run
                        (~hwif_out.hwpe_ctrl.autotrigger.autotrigger_n.value & job_done_q & ~job_fifo_empty); // trigger with autotrigger if active and there are pending jobs
 
   // ACQUIRE register:

--- a/rtl/hwpe_ctrl_target.sv
+++ b/rtl/hwpe_ctrl_target.sv
@@ -93,6 +93,7 @@ module hwpe_ctrl_target
   parameter int unsigned NB_CLEAR_CYCLES = 3,
   parameter int unsigned ID_WIDTH        = 2,
   parameter int unsigned ADDR_WIDTH      = 16,
+  parameter int unsigned AUTOTRIGGER_WAIT_CYCLES = 3,
   parameter type hwpe_ctrl_regif_in_t  = logic, // must be overridden!
   parameter type hwpe_ctrl_regif_out_t = logic, // must be overridden!
   parameter type hwpe_ctrl_job_indep_t = logic, // must be overridden!
@@ -204,8 +205,10 @@ module hwpe_ctrl_target
   // current and next running job ID
   logic [7:0] job_running_id_d, job_running_id_q;
 
-  // delayed job done
+  // delayed job done (job_done_i delayed by AUTOTRIGGER_WAIT_CYCLES cycles;
+  // AUTOTRIGGER_WAIT_CYCLES=1 reproduces the original single-register delay)
   logic job_done_q;
+  logic [AUTOTRIGGER_WAIT_CYCLES-1:0] job_done_sr_q;
 
   // job commit signal
   logic job_commit;
@@ -218,19 +221,23 @@ module hwpe_ctrl_target
   logic [NB_CLEAR_CYCLES-1:0] soft_clear_regfile_q, soft_clear_state_q;
   logic                       soft_clear_regfile_en, soft_clear_state_en;
 
-  // Registered job_done
+  // Registered job_done, delayed by AUTOTRIGGER_WAIT_CYCLES cycles
   always_ff @(posedge clk_i or negedge rst_ni)
   begin
     if(~rst_ni) begin
-      job_done_q <= '0;
+      job_done_sr_q <= '0;
     end
     else if(|soft_clear_regfile_q) begin
-      job_done_q <= '0;
+      job_done_sr_q <= '0;
     end
     else begin
-      job_done_q <= job_done_i;
+      job_done_sr_q[0] <= job_done_i;
+      for(int i=1; i<AUTOTRIGGER_WAIT_CYCLES; i++) begin
+        job_done_sr_q[i] <= job_done_sr_q[i-1];
+      end
     end
   end
+  assign job_done_q = job_done_sr_q[AUTOTRIGGER_WAIT_CYCLES-1];
 
   // Registered software-access strobes for the write-command registers.
   // PeakRDL exposes `.value` from the registered field storage (updated one cycle after a

--- a/rtl/hwpe_ctrl_target.sv
+++ b/rtl/hwpe_ctrl_target.sv
@@ -205,6 +205,9 @@ module hwpe_ctrl_target
   // current and next running job ID
   logic [7:0] job_running_id_d, job_running_id_q;
 
+  // job running flag: set (0->1) when job_trigger_o fires, cleared (1->0) by job_done_early_q
+  logic job_running_q;
+
   // delayed job done (job_done_i delayed by AUTOTRIGGER_WAIT_CYCLES cycles;
   // AUTOTRIGGER_WAIT_CYCLES=1 reproduces the original single-register delay)
   logic job_done_q;
@@ -238,6 +241,17 @@ module hwpe_ctrl_target
     end
   end
   assign job_done_q = job_done_sr_q[AUTOTRIGGER_WAIT_CYCLES-1];
+
+  // job_done_i delayed by AUTOTRIGGER_WAIT_CYCLES-1 cycles
+  logic job_done_early_q;
+  generate
+    if (AUTOTRIGGER_WAIT_CYCLES > 1) begin : gen_job_done_early_geq2_gen
+      assign job_done_early_q = job_done_sr_q[AUTOTRIGGER_WAIT_CYCLES-2];
+    end
+    else begin : gen_job_done_early_eq1_gen
+      assign job_done_early_q = job_done_i;
+    end
+  endgenerate
 
   // Registered software-access strobes for the write-command registers.
   // PeakRDL exposes `.value` from the registered field storage (updated one cycle after a
@@ -296,7 +310,7 @@ module hwpe_ctrl_target
   // COMMIT_TRIGGER register:
   // Commit a job in the job queue if COMMIT_TRIGGER[1] is 1'b0. Trigger the job queue execution if COMMIT_TRIGGER[0] is 1'b0.
   assign job_commit    =  commit_trigger_swacc_q & ~hwif_out.hwpe_ctrl.commit_trigger.commit_trigger.value[1];
-  assign job_trigger_o = (commit_trigger_swacc_q & ~hwif_out.hwpe_ctrl.commit_trigger.commit_trigger.value[0]) | // trigger when a TRIGGER arrives
+  assign job_trigger_o = (commit_trigger_swacc_q & ~hwif_out.hwpe_ctrl.commit_trigger.commit_trigger.value[0] & ~job_running_q) | // trigger when a TRIGGER arrives and no job is running
                          (~hwif_out.hwpe_ctrl.autotrigger.autotrigger_n.value & job_done_q & ~job_fifo_empty); // trigger with autotrigger if active and there are pending jobs
 
   // ACQUIRE register:
@@ -334,6 +348,22 @@ module hwpe_ctrl_target
     end
   end
   assign job_running_id_d = job_running_id_q + 1;
+
+  always_ff @(posedge clk_i or negedge rst_ni)
+  begin
+    if(~rst_ni) begin
+      job_running_q <= 1'b0;
+    end
+    else if(|soft_clear_regfile_q) begin
+      job_running_q <= 1'b0;
+    end
+    else if(job_trigger_o) begin
+      job_running_q <= 1'b1;
+    end
+    else if(job_done_early_q) begin
+      job_running_q <= 1'b0;
+    end
+  end
 
   // enable state change on ACQUIRE / COMMIT_TRIGGER register access
   logic job_offload_state_en;

--- a/rtl/hwpe_ctrl_target.sv
+++ b/rtl/hwpe_ctrl_target.sv
@@ -309,9 +309,10 @@ module hwpe_ctrl_target
 
   // COMMIT_TRIGGER register:
   // Commit a job in the job queue if COMMIT_TRIGGER[1] is 1'b0. Trigger the job queue execution if COMMIT_TRIGGER[0] is 1'b0.
-  assign job_commit    =  commit_trigger_swacc_q & ~hwif_out.hwpe_ctrl.commit_trigger.commit_trigger.value[1];
-  assign job_trigger_o = (commit_trigger_swacc_q & ~hwif_out.hwpe_ctrl.commit_trigger.commit_trigger.value[0] & ~job_running_q) | // trigger when a TRIGGER arrives and no job is running
-                         (~hwif_out.hwpe_ctrl.autotrigger.autotrigger_n.value & job_done_q & ~job_fifo_empty); // trigger with autotrigger if active and there are pending jobs
+assign job_commit    =  commit_trigger_swacc_q & ~hwif_out.hwpe_ctrl.commit_trigger.commit_trigger.value[1];
+assign job_trigger_o = (commit_trigger_swacc_q & ~hwif_out.hwpe_ctrl.commit_trigger.commit_trigger.value[0] & ~job_running_q &
+                        (job_commit | ~job_fifo_empty)) | // trigger when a TRIGGER arrives, no job is running, and there is (or will be) a job to run
+                       (~hwif_out.hwpe_ctrl.autotrigger.autotrigger_n.value & job_done_q & ~job_fifo_empty); // trigger with autotrigger if active and there are pending jobs
 
   // ACQUIRE register:
   // 1. if in ACQUIRE state, respond to any new reads with error code (-2)


### PR DESCRIPTION
This pull request re-introduces an "autotrigger" feature to the HWPE controller, allowing jobs to be automatically triggered when the previous job finishes, unless an explicit trigger is required. The changes include updates to the register interface and the controller logic to support configurable autotrigger behavior, as well as improved handling of job completion signals.
Differently from the past, auto-triggering is enabled by default but can be disable by writing a 1 to a specific `AUTOTRIGGER` register.

**Autotrigger Feature Implementation:**

* Added a new `autotrigger` register to the HWPE register interface (`hwpe_ctrl_regif_example.rdl`), replacing the previous reserved register at offset 0x08. This register includes an `autotrigger_n` field to enable or disable automatic triggering of jobs. [[1]](diffhunk://#diff-43f3411c3b8de7c7b7b440ea6b1dd2e817604a0a294a4a8a1eaf106e35590527L51-R64) [[2]](diffhunk://#diff-43f3411c3b8de7c7b7b440ea6b1dd2e817604a0a294a4a8a1eaf106e35590527R106-R120)

* Modified the `ctrl_mandatory` register file to use the new `autotrigger` register instead of the previous reserved register.

**Controller Logic Enhancements:**

* Added the `AUTOTRIGGER_WAIT_CYCLES` parameter to control the number of cycles to wait before autotriggering a new job after completion.

* Implemented logic to delay the `job_done` signal by `AUTOTRIGGER_WAIT_CYCLES` cycles, ensuring proper synchronization and timing for autotrigger events. [[1]](diffhunk://#diff-1e8276b99c1a5b08b3cc07aa527da493822de1e0194828331c2f39e1d15497f2R208-R215) [[2]](diffhunk://#diff-1e8276b99c1a5b08b3cc07aa527da493822de1e0194828331c2f39e1d15497f2R227-R255)

* Updated the job triggering logic to support both explicit and automatic triggering based on the `autotrigger_n` field, and to prevent job overlap.

* Added a `job_running_q` flag to track when a job is running, ensuring correct job state transitions and preventing multiple triggers. [[1]](diffhunk://#diff-1e8276b99c1a5b08b3cc07aa527da493822de1e0194828331c2f39e1d15497f2R208-R215) [[2]](diffhunk://#diff-1e8276b99c1a5b08b3cc07aa527da493822de1e0194828331c2f39e1d15497f2R352-R367)